### PR TITLE
Add sensors and outlet control for A91B2

### DIFF
--- a/custom_components/anker_solix/api_client.py
+++ b/custom_components/anker_solix/api_client.py
@@ -794,6 +794,11 @@ class AnkerSolixApiClient:
                             ).create_device()
                         ):
                             self.mqtt_devices[sn] = mdev
+                    # Auto-send status request and realtime trigger for newly created MQTT devices
+                    for mdev in self.mqtt_devices.values():
+                        if mdev.device.get("mqtt_status_request"):
+                            await mdev.status_request()
+                        await mdev.realtime_trigger()
                     # Note: The method for update callback will be checked and set during coordinator updates
                 else:
                     _LOGGER.error(

--- a/custom_components/anker_solix/solixapi/apibase.py
+++ b/custom_components/anker_solix/solixapi/apibase.py
@@ -766,6 +766,8 @@ class AnkerSolixBaseApi:
                                 "usbc_3_switch",
                                 "usbc_4_switch",
                                 "usba_switch",
+                                "ac_1_switch",
+                                "ac_2_switch",
                                 "dc_12v_auto_on",  # missing MQTT control command
                                 "usage_mode",
                                 "energy_saving_mode",  # missing MQTT control command

--- a/custom_components/anker_solix/solixapi/mqtt_charger.py
+++ b/custom_components/anker_solix/solixapi/mqtt_charger.py
@@ -36,6 +36,8 @@ FEATURES = {
     SolixMqttCommands.usbc_3_port_switch: MODELS,
     SolixMqttCommands.usbc_4_port_switch: MODELS,
     SolixMqttCommands.usba_port_switch: MODELS,
+    SolixMqttCommands.ac_1_port_switch: {"A91B2"},
+    SolixMqttCommands.ac_2_port_switch: {"A91B2"},
     SolixMqttCommands.plug_lock_switch: MODELS,
     SolixMqttCommands.ev_auto_start_switch: MODELS,
     SolixMqttCommands.ev_auto_charge_restart_switch: MODELS,

--- a/custom_components/anker_solix/solixapi/mqttcmdmap.py
+++ b/custom_components/anker_solix/solixapi/mqttcmdmap.py
@@ -93,6 +93,8 @@ class SolixMqttCommands:
     usbc_3_port_switch: str = "usbc_3_port_switch"
     usbc_4_port_switch: str = "usbc_4_port_switch"
     usba_port_switch: str = "usba_port_switch"
+    ac_1_port_switch: str = "ac_1_port_switch"
+    ac_2_port_switch: str = "ac_2_port_switch"
     soc_limits: str = "soc_limits"
     sb_status_check: str = "sb_status_check"
     sb_power_cutoff_select: str = "sb_power_cutoff_select"

--- a/custom_components/anker_solix/solixapi/mqttmap.py
+++ b/custom_components/anker_solix/solixapi/mqttmap.py
@@ -4212,6 +4212,125 @@ SOLIXMQTTMAP: Final[dict] = {
         # Interval: only with status request command. Contains all settings and consumption data
         "0a00": _A2345_0a00,
     },
+    # Prime Charging Station 240W 8-in-1
+    "A91B2": {
+        "0200": CMD_STATUS_REQUEST,  # Device status request for message 0a00
+        "0207": {
+            # AC outlet switch command. Same message type as A2345 USB port switch.
+            # port_select: 0=ac_1, 1=ac_2
+            COMMAND_LIST: [
+                SolixMqttCommands.ac_1_port_switch,
+                SolixMqttCommands.ac_2_port_switch,
+            ],
+            SolixMqttCommands.ac_1_port_switch: CMD_USB_PORT_SWITCH
+            | {
+                "a2": {
+                    **CMD_USB_PORT_SWITCH["a2"],
+                    VALUE_DEFAULT: 0,
+                    VALUE_OPTIONS: {
+                        "ac_1_switch": 0,
+                        "ac_2_switch": 1,
+                    },
+                },
+                "a3": {
+                    **CMD_USB_PORT_SWITCH["a3"],
+                    STATE_NAME: "ac_1_switch",
+                },
+            },
+            SolixMqttCommands.ac_2_port_switch: CMD_USB_PORT_SWITCH
+            | {
+                "a2": {
+                    **CMD_USB_PORT_SWITCH["a2"],
+                    VALUE_DEFAULT: 1,
+                    VALUE_OPTIONS: {
+                        "ac_1_switch": 0,
+                        "ac_2_switch": 1,
+                    },
+                },
+                "a3": {
+                    **CMD_USB_PORT_SWITCH["a3"],
+                    STATE_NAME: "ac_2_switch",
+                },
+            },
+        },
+        # Special realtime trigger (no a2/a3 timeout params, same as A2345)
+        "020b": {
+            k: v for k, v in CMD_REALTIME_TRIGGER.items() if k not in ["a2", "a3"]
+        },
+        # Port switch state notification (broadcast by device after 0207 command)
+        "0302": {
+            "a2": {NAME: "set_port_switch_select"},
+            "a3": {NAME: "set_port_switch"},
+            "fe": {NAME: "msg_timestamp"},
+        },
+        # Interval: ~1 second with realtime trigger. USB port consumption data (same layout as A2345).
+        "0303": _A2345_0303,
+        # Full device status including AC outlet switch states, sent on status request.
+        "0a00": {
+            "a2": {NAME: "sw_version", "values": 3},
+            # USB ports: a4=usbc_1 ... a9=usba_2 (same 8-byte structure as A2345 0a00)
+            "a4": {
+                BYTES: {
+                    "00": {NAME: "usbc_1_status", TYPE: DeviceHexDataTypes.ui.value},
+                    "01": {NAME: "usbc_1_voltage", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.001},
+                    "03": {NAME: "usbc_1_current", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.001},
+                    "05": {NAME: "usbc_1_power", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.01},
+                }
+            },
+            "a5": {
+                BYTES: {
+                    "00": {NAME: "usbc_2_status", TYPE: DeviceHexDataTypes.ui.value},
+                    "01": {NAME: "usbc_2_voltage", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.001},
+                    "03": {NAME: "usbc_2_current", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.001},
+                    "05": {NAME: "usbc_2_power", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.01},
+                }
+            },
+            "a6": {
+                BYTES: {
+                    "00": {NAME: "usbc_3_status", TYPE: DeviceHexDataTypes.ui.value},
+                    "01": {NAME: "usbc_3_voltage", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.001},
+                    "03": {NAME: "usbc_3_current", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.001},
+                    "05": {NAME: "usbc_3_power", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.01},
+                }
+            },
+            "a7": {
+                BYTES: {
+                    "00": {NAME: "usbc_4_status", TYPE: DeviceHexDataTypes.ui.value},
+                    "01": {NAME: "usbc_4_voltage", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.001},
+                    "03": {NAME: "usbc_4_current", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.001},
+                    "05": {NAME: "usbc_4_power", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.01},
+                }
+            },
+            "a8": {
+                BYTES: {
+                    "00": {NAME: "usba_1_status", TYPE: DeviceHexDataTypes.ui.value},
+                    "01": {NAME: "usba_1_voltage", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.001},
+                    "03": {NAME: "usba_1_current", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.001},
+                    "05": {NAME: "usba_1_power", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.01},
+                }
+            },
+            "a9": {
+                BYTES: {
+                    "00": {NAME: "usba_2_status", TYPE: DeviceHexDataTypes.ui.value},
+                    "01": {NAME: "usba_2_voltage", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.001},
+                    "03": {NAME: "usba_2_current", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.001},
+                    "05": {NAME: "usba_2_power", TYPE: DeviceHexDataTypes.sile.value, FACTOR: 0.01},
+                }
+            },
+            # AC outlet switch states: byte "00" of f_value = 0 (off) or 1 (on)
+            "aa": {
+                BYTES: {
+                    "00": {NAME: "ac_1_switch", TYPE: DeviceHexDataTypes.ui.value},
+                },
+            },
+            "ab": {
+                BYTES: {
+                    "00": {NAME: "ac_2_switch", TYPE: DeviceHexDataTypes.ui.value},
+                },
+            },
+            "fe": {NAME: "msg_timestamp"},
+        },
+    },
     # Power Panel
     "A17B1": {
         "0057": CMD_REALTIME_TRIGGER,  # for regular status messages

--- a/custom_components/anker_solix/switch.py
+++ b/custom_components/anker_solix/switch.py
@@ -302,6 +302,24 @@ DEVICE_SWITCHES = [
         mqtt=True,
         mqtt_cmd=SolixMqttCommands.usba_port_switch,
     ),
+    AnkerSolixSwitchDescription(
+        key="ac_1_switch",
+        translation_key="ac_1_switch",
+        json_key="ac_1_switch",
+        exclude_fn=lambda s, d: not ({d.get("type")} - s),
+        device_class=SwitchDeviceClass.OUTLET,
+        mqtt=True,
+        mqtt_cmd=SolixMqttCommands.ac_1_port_switch,
+    ),
+    AnkerSolixSwitchDescription(
+        key="ac_2_switch",
+        translation_key="ac_2_switch",
+        json_key="ac_2_switch",
+        exclude_fn=lambda s, d: not ({d.get("type")} - s),
+        device_class=SwitchDeviceClass.OUTLET,
+        mqtt=True,
+        mqtt_cmd=SolixMqttCommands.ac_2_port_switch,
+    ),
 ]
 
 

--- a/custom_components/anker_solix/translations/en.json
+++ b/custom_components/anker_solix/translations/en.json
@@ -2147,6 +2147,12 @@
             "usba_switch": {
                 "name": "USB-A ports"
             },
+            "ac_1_switch": {
+                "name": "AC outlet 1"
+            },
+            "ac_2_switch": {
+                "name": "AC outlet 2"
+            },
             "allow_refresh": {
                 "name": "Api Usage",
                 "state_attributes": {


### PR DESCRIPTION
Add MQTT support for Anker Prime 8-in-1 240W Charging Station (A91B2)

  Summary

  - Adds full MQTT message decoding and AC outlet switch control for the A91B2 (240W Charging Station 8-in-1)
  - USB port power sensors (USB-C 1-4, USB-A 1-2) and AC outlet on/off switches now appear as HA entities
  - Status request and realtime trigger are sent automatically on MQTT session connect, so entities populate without manual button presses

  Changes

  MQTT message mappings (solixapi/mqttmap.py):
  - Added SOLIXMQTTMAP["A91B2"] with decoded mappings for message types 0303 (realtime USB port data, reuses _A2345_0303), 0a00 (full status including AC outlet switch states at fields aa/ab), 0207 (AC outlet switch command), 0302 (switch state
  notification), and 020b (realtime trigger)

  AC outlet switch commands (solixapi/mqttcmdmap.py):
  - Added ac_1_port_switch and ac_2_port_switch to SolixMqttCommands

  Device features (solixapi/mqtt_charger.py):
  - Added AC outlet switch features scoped to {"A91B2"} only

  MQTT value whitelist (solixapi/apibase.py):
  - Added ac_1_switch and ac_2_switch to the key whitelist in update_device_mqtt so extracted values pass through to the device cache

  Switch entities (switch.py):
  - Added ac_1_switch and ac_2_switch entity descriptions with SwitchDeviceClass.OUTLET

  Translations (translations/en.json):
  - Added "AC outlet 1" and "AC outlet 2" display names

  Auto-trigger on connect (api_client.py):
  - After MQTT device creation, automatically sends status_request (for devices that support it) and realtime_trigger so entities are populated immediately without manual button presses

  Protocol details

  - The A91B2 0303 message uses the same TLV structure as the A2345 (250W Prime Charger)
  - The 0a00 message includes 19-byte AC outlet fields at tags aa/ab, where byte "00" of f_value is the switch state (0=off, 1=on)
  - The 0207 switch command uses the standard CMD_USB_PORT_SWITCH format with port_select=0 for AC outlet 1 and port_select=1 for AC outlet 2
  - Decoded via MQTT capture using mqtt_monitor.py from https://github.com/thomluther/anker-solix-api

  Testing

  Tested on two physical A91B2 devices ("Living Room Charging Station" and "Sunroom Charging Station") running firmware v1.1.2.4.